### PR TITLE
fix audio playback on m4a files without extension

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ websockets
 requests
 pygame
 pydub
+filetype

--- a/sources/audioPlayer.py
+++ b/sources/audioPlayer.py
@@ -55,21 +55,6 @@ def set_volume(vol):
         vol = vol / 2
     mixer_music.set_volume(vol / 100)
 
-def get_file_extension(url):
-    # Parse the URL to get the path
-    path = urlparse(url).path
-    # Split the path based on '/'
-    parts = path.split('/')
-    # Get the last part of the path, which represents the file name
-    file_name = parts[-1]
-    # Split the file name based on '?' to handle parameters
-    file_name_parts = file_name.split('?')
-    # Get the first part of the file name, which represents the actual file name
-    actual_file_name = file_name_parts[0]
-    # Split the actual file name based on '.', and get the last part, which represents the file extension
-    extension = actual_file_name.split('.')[-1]
-    return extension
-
 def convert_audio(file_path, output_dir):
     audio = AudioSegment.from_file(file_path)
     audio.export(output_dir, format='mp3')
@@ -110,7 +95,7 @@ def set_audio(url='https://github.com/anars/blank-audio/blob/master/250-millisec
                 print('File is not valid!')
                 set_audio()
 
-            # Update file extension variable with true file type
+            # Get the file extension of the audio
             ext = kind.extension
 
             # Convert the file to mp3 if it downloads an unsupported file format

--- a/sources/audioPlayer.py
+++ b/sources/audioPlayer.py
@@ -3,6 +3,7 @@ import json
 import requests
 import pygame
 import tempfile
+import filetype
 from datetime import datetime
 from pygame import mixer_music
 from pydub import AudioSegment
@@ -18,7 +19,7 @@ fadein = True
 debounce = False
 
 # Audio Stuff
-unsupported_formats = {"m4a"}
+unsupported_formats = {"mp4"}
 audio_cache = {}
 filename = ""
 audio_folder = "fe2io_files"
@@ -103,8 +104,14 @@ def set_audio(url='https://github.com/anars/blank-audio/blob/master/250-millisec
             response = requests.get(url)
             response.raise_for_status()
 
-            # Get the file extension of the audio
-            ext = get_file_extension(url)
+            # Get the file kind of the audio
+            kind = filetype.guess(response.content)
+            if kind is None:
+                print('File is not valid!')
+                set_audio()
+
+            # Update file extension variable with true file type
+            ext = kind.extension
 
             # Convert the file to mp3 if it downloads an unsupported file format
             if ext in unsupported_formats:


### PR DESCRIPTION
Fixes audio playback of m4a files that are downloaded without an extension. Most notably in True Failure, but also for any m4a format file downloaded from Jukehost. It accomplishes this by using a library that determines the file extension of the audio through the magic number (a header on the file which is unique for each file type). The file format returned is mp4 because an m4a's file's MIME type is audio/mp4, oddly enough. This fixes #1 